### PR TITLE
Add CloudWatch API abstraction layer

### DIFF
--- a/internal/awsapi/client.go
+++ b/internal/awsapi/client.go
@@ -1,0 +1,52 @@
+package awsapi
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+)
+
+// CloudWatchAPI defines the interface for CloudWatch operations.
+type CloudWatchAPI interface {
+	DescribeAlarms(
+		ctx context.Context,
+		input *cloudwatch.DescribeAlarmsInput,
+		optFns ...func(*cloudwatch.Options)) (*cloudwatch.DescribeAlarmsOutput, error)
+
+	GetMetricData(
+		ctx context.Context,
+		input *cloudwatch.GetMetricDataInput,
+		optFns ...func(*cloudwatch.Options)) (*cloudwatch.GetMetricDataOutput, error)
+
+	ListMetrics(
+		ctx context.Context,
+		input *cloudwatch.ListMetricsInput,
+		optFns ...func(*cloudwatch.Options)) (*cloudwatch.ListMetricsOutput, error)
+}
+
+// Client wraps the AWS CloudWatch client and implements CloudWatchAPI interface.
+type Client struct {
+	cw *cloudwatch.Client
+}
+
+// NewClient creates a new CloudWatch service instance.
+func NewClient(cw *cloudwatch.Client) *Client {
+	return &Client{
+		cw: cw,
+	}
+}
+
+// DescribeAlarms retrieves information about CloudWatch alarms.
+func (c *Client) DescribeAlarms(ctx context.Context, input *cloudwatch.DescribeAlarmsInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.DescribeAlarmsOutput, error) {
+	return c.cw.DescribeAlarms(ctx, input, optFns...)
+}
+
+// GetMetricData retrieves metric data for CloudWatch metrics.
+func (c *Client) GetMetricData(ctx context.Context, input *cloudwatch.GetMetricDataInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.GetMetricDataOutput, error) {
+	return c.cw.GetMetricData(ctx, input, optFns...)
+}
+
+// ListMetrics retrieves a list of CloudWatch metrics.
+func (c *Client) ListMetrics(ctx context.Context, input *cloudwatch.ListMetricsInput, optFns ...func(*cloudwatch.Options)) (*cloudwatch.ListMetricsOutput, error) {
+	return c.cw.ListMetrics(ctx, input, optFns...)
+}

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ab0utbla-k/cloudwatch-alarm-enricher/internal/awsapi"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -20,7 +21,7 @@ import (
 )
 
 type LambdaHandler struct {
-	cwClient    *cloudwatch.Client
+	cwClient    awsapi.CloudWatchAPI
 	snsClient   *sns.Client
 	snsTopicArn string
 	logger      *slog.Logger
@@ -42,7 +43,7 @@ func NewLambdaHandler() (*LambdaHandler, error) {
 	}
 
 	return &LambdaHandler{
-		cwClient:    cloudwatch.NewFromConfig(cfg),
+		cwClient:    awsapi.NewClient(cloudwatch.NewFromConfig(cfg)),
 		snsClient:   sns.NewFromConfig(cfg),
 		snsTopicArn: snsTopicArn,
 		logger:      logger,


### PR DESCRIPTION
This PR introduces an interface-based abstraction for CloudWatch operations to improve testability and maintainability.

  - Added internal/awsapi package:
    - CloudWatchAPI interface defining CloudWatch operations
    - Client struct implementing the interface as a wrapper around AWS SDK
  - Updated LambdaHandler:
    - Changed cwClient field from concrete *cloudwatch.Client to awsapi.CloudWatchAPI interface
    - Updated constructor to use the new abstraction layer