### PR TITLE
fix: Message formatting and metric query period alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Required environment variables:
 
 ```bash
 # Build
-go build -o main cmd/lambda/main.go
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bootstrap ./cmd/lambda
 
 # Deploy using your preferred method (SAM, CDK, Terraform, etc.)
 ```

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.31.12
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.51.1
 	github.com/aws/aws-sdk-go-v2/service/sns v1.38.5
+	github.com/stretchr/testify v1.7.2
 )
 
 require (
@@ -22,4 +23,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.38.6 // indirect
 	github.com/aws/smithy-go v1.23.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.1.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -30,11 +30,16 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.38.6 h1:p3jIvqYwUZgu/XYeI48bJxOhvm47
 github.com/aws/aws-sdk-go-v2/service/sts v1.38.6/go.mod h1:WtKK+ppze5yKPkZ0XwqIVWD4beCwv056ZbPQNoeHqM8=
 github.com/aws/smithy-go v1.23.0 h1:8n6I3gXzWJB2DxBDnfxgBaSX6oe0d/t10qGz7OKqMCE=
 github.com/aws/smithy-go v1.23.0/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/metrics/analyzer_test.go
+++ b/internal/metrics/analyzer_test.go
@@ -1,0 +1,54 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAlignToPeriodBoundary(t *testing.T) {
+	// 1-day period aligns to midnight UTC
+	// This is critical: CloudWatch returns NO DATA for daily metrics with misaligned time windows
+	input := time.Date(2025, 10, 2, 6, 38, 15, 0, time.UTC)
+	period := 24 * time.Hour
+	expected := time.Date(2025, 10, 2, 0, 0, 0, 0, time.UTC)
+	result := alignToPeriodBoundary(input, period)
+	assert.Equal(t, expected, result)
+	assert.NotEqual(t, input, result, "Time must be aligned, not left as-is")
+
+	// 1-day period at midnight stays at midnight
+	input = time.Date(2025, 10, 2, 0, 0, 0, 0, time.UTC)
+	period = 24 * time.Hour
+	expected = time.Date(2025, 10, 2, 0, 0, 0, 0, time.UTC)
+	result = alignToPeriodBoundary(input, period)
+	assert.Equal(t, expected, result)
+
+	// 5-minute period rounds down
+	input = time.Date(2025, 10, 2, 6, 38, 15, 0, time.UTC)
+	period = 5 * time.Minute
+	expected = time.Date(2025, 10, 2, 6, 35, 0, 0, time.UTC)
+	result = alignToPeriodBoundary(input, period)
+	assert.Equal(t, expected, result)
+
+	// 5-minute period at exact boundary
+	input = time.Date(2025, 10, 2, 6, 35, 0, 0, time.UTC)
+	period = 5 * time.Minute
+	expected = time.Date(2025, 10, 2, 6, 35, 0, 0, time.UTC)
+	result = alignToPeriodBoundary(input, period)
+	assert.Equal(t, expected, result)
+
+	// 1-hour period rounds down
+	input = time.Date(2025, 10, 2, 6, 38, 15, 0, time.UTC)
+	period = 1 * time.Hour
+	expected = time.Date(2025, 10, 2, 6, 0, 0, 0, time.UTC)
+	result = alignToPeriodBoundary(input, period)
+	assert.Equal(t, expected, result)
+
+	// 1-minute period rounds down
+	input = time.Date(2025, 10, 2, 6, 38, 42, 0, time.UTC)
+	period = 1 * time.Minute
+	expected = time.Date(2025, 10, 2, 6, 38, 0, 0, time.UTC)
+	result = alignToPeriodBoundary(input, period)
+	assert.Equal(t, expected, result)
+}

--- a/internal/notification/message.go
+++ b/internal/notification/message.go
@@ -2,6 +2,7 @@ package notification
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -49,20 +50,21 @@ func (f *TextMessageFormatter) Format(event *alarm.EnrichedEvent) (string, error
 			return "", err
 		}
 
-		for _, vm := range event.ViolatingMetrics {
+		for i, vm := range event.ViolatingMetrics {
 			dms := make([]string, 0, len(vm.Dimensions))
 			for k, v := range vm.Dimensions {
 				dms = append(dms, k+"="+v)
 			}
 
-			_, err = fmt.Fprintf(&msg, "• %s, Value: %.2f",
+			slices.Sort(dms)
+
+			_, err = fmt.Fprintf(&msg, "%d. %s, Value: %.2f\t\n",
+				i+1,
 				strings.Join(dms, ", "),
 				vm.Value)
 			if err != nil {
 				return "", err
 			}
-
-			msg.WriteByte('\n')
 		}
 	}
 

--- a/internal/notification/message_test.go
+++ b/internal/notification/message_test.go
@@ -1,0 +1,127 @@
+package notification
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ab0utbla-k/cloudwatch-alarm-enricher/internal/alarm"
+	"github.com/ab0utbla-k/cloudwatch-alarm-enricher/internal/metrics"
+)
+
+func TestTextMessageFormatter_NoViolations(t *testing.T) {
+	formatter := &TextMessageFormatter{}
+
+	event := &alarm.EnrichedEvent{
+		Alarm: &types.MetricAlarm{
+			AlarmName:   aws.String("TestAlarm"),
+			StateValue:  types.StateValueAlarm,
+			StateReason: aws.String("Threshold breached"),
+			Threshold:   aws.Float64(100.0),
+		},
+		ViolatingMetrics: []metrics.ViolatingMetric{},
+		Timestamp:        time.Date(2025, 10, 2, 12, 0, 0, 0, time.UTC),
+	}
+
+	message, err := formatter.Format(event)
+	require.NoError(t, err)
+	assert.Contains(t, message, "TestAlarm")
+	assert.Contains(t, message, "ALARM")
+	assert.Contains(t, message, "No specific services currently violating the threshold")
+}
+
+func TestTextMessageFormatter_WithViolations(t *testing.T) {
+	formatter := &TextMessageFormatter{}
+
+	event := &alarm.EnrichedEvent{
+		Alarm: &types.MetricAlarm{
+			AlarmName:          aws.String("HighErrorRate"),
+			StateValue:         types.StateValueAlarm,
+			StateReason:        aws.String("Threshold breached"),
+			Threshold:          aws.Float64(10.0),
+			ComparisonOperator: types.ComparisonOperatorGreaterThanThreshold,
+		},
+		ViolatingMetrics: []metrics.ViolatingMetric{
+			{
+				Value: 15.5,
+				Dimensions: map[string]string{
+					"ServiceName": "api-service",
+					"Environment": "production",
+				},
+				Timestamp: time.Date(2025, 10, 2, 12, 0, 0, 0, time.UTC),
+			},
+			{
+				Value: 20.3,
+				Dimensions: map[string]string{
+					"ServiceName": "worker-service",
+				},
+				Timestamp: time.Date(2025, 10, 2, 12, 0, 0, 0, time.UTC),
+			},
+		},
+		Timestamp: time.Date(2025, 10, 2, 12, 0, 0, 0, time.UTC),
+	}
+
+	message, err := formatter.Format(event)
+	require.NoError(t, err)
+	require.Contains(t, message, "HighErrorRate")
+	require.Contains(t, message, "ALARM")
+	require.Contains(t, message, "> 10.0")
+	require.Contains(t, message, "api-service")
+	require.Contains(t, message, "15.50")
+	require.Contains(t, message, "worker-service")
+	require.Contains(t, message, "20.30")
+}
+
+func TestTextMessageFormatter_DimensionsSorted(t *testing.T) {
+	formatter := &TextMessageFormatter{}
+
+	event := &alarm.EnrichedEvent{
+		Alarm: &types.MetricAlarm{
+			AlarmName:          aws.String("TestAlarm"),
+			StateValue:         types.StateValueAlarm,
+			StateReason:        aws.String("Test"),
+			Threshold:          aws.Float64(5.0),
+			ComparisonOperator: types.ComparisonOperatorGreaterThanOrEqualToThreshold,
+		},
+		ViolatingMetrics: []metrics.ViolatingMetric{
+			{
+				Value: 10.0,
+				Dimensions: map[string]string{
+					"ZZZ": "last",
+					"AAA": "first",
+					"MMM": "middle",
+				},
+				Timestamp: time.Now(),
+			},
+		},
+		Timestamp: time.Now(),
+	}
+
+	message, err := formatter.Format(event)
+	require.NoError(t, err)
+	require.Contains(t, message, "AAA=first, MMM=middle, ZZZ=last")
+	slog.Info("HERE", "msg", message)
+}
+
+func TestGetComparisonSymbol(t *testing.T) {
+	symbol, err := getComparisonSymbol(types.ComparisonOperatorGreaterThanThreshold)
+	require.NoError(t, err)
+	require.Equal(t, ">", symbol)
+
+	symbol, err = getComparisonSymbol(types.ComparisonOperatorGreaterThanOrEqualToThreshold)
+	require.NoError(t, err)
+	require.Equal(t, ">=", symbol)
+
+	symbol, err = getComparisonSymbol(types.ComparisonOperatorLessThanThreshold)
+	require.NoError(t, err)
+	require.Equal(t, "<", symbol)
+
+	symbol, err = getComparisonSymbol(types.ComparisonOperatorLessThanOrEqualToThreshold)
+	require.NoError(t, err)
+	require.Equal(t, "<=", symbol)
+}


### PR DESCRIPTION
- Fixed 1-day period metric queries - Added alignToPeriodBoundary
function to properly align CloudWatch metric queries to period
boundaries. This fixes an issue where daily metrics returned no data
when queried with misaligned time windows (e.g., 07:31-07:31 instead
of 00:00-00:00). For periods ≥24 hours, aligns to midnight UTC; for
shorter periods, rounds down to nearest boundary.
- Improved violation message formatting - Updated violating metrics
display to use numbered list format (1., 2., etc.) instead of bullet
points, sorted dimension key-value pairs alphabetically for
consistent output, and cleaned up formatting by using tab separator.